### PR TITLE
fix mismatch jira form fields

### DIFF
--- a/utils/jira/functions.ts
+++ b/utils/jira/functions.ts
@@ -299,16 +299,16 @@ export const formatJiraITAssetPayload = ({
         "20": {
           choices: [assignee.suffix ?? ""],
         },
-        "21": {
+        "33": {
           text: assignee.firstName,
         },
-        "22": {
+        "34": {
           text: assignee.middleName ?? "",
         },
-        "23": {
+        "31": {
           text: assignee.lastName,
         },
-        "26": {
+        "29": {
           text: assignee.employeeId,
         },
       },


### PR DESCRIPTION
**Bug:** Empty assignee information data in jira ticket
**Cause:** Mismatch in jira form fields caused by update to existing form. Jira updates the keys of form fields if fields are changed.